### PR TITLE
fix: Fix typo in Slackened::Error's constructor

### DIFF
--- a/lib/slackened/error.rb
+++ b/lib/slackened/error.rb
@@ -7,7 +7,7 @@ module Slackened
 		def initialize(http_response)
 			@response = http_response
 
-			super("#{@response.code} #{@response.message}: #{@response.body}")
+			super("#{@response.code} #{@response.msg}: #{@response.body}")
 		end
 	end
 end


### PR DESCRIPTION
21e602be4ef802a600cb90dad13fe1ed1a1a5c4c adds `Slackened::Error` to wrap `Net::HTTP` errors and 41411d022800f5719f934a7a5ea50ca52dac0861 adds `Slackened::Response` to wrap the `Net::HTTP` responses.

`Slackened::Response`'s attribute is called `msg`, not `message`. This PR fixes this typo.